### PR TITLE
Support the lame behavior of not specifying versions for your deps.

### DIFF
--- a/lib/hoe/bundler.rb
+++ b/lib/hoe/bundler.rb
@@ -16,10 +16,12 @@ class Hoe #:nodoc:
           gemfile.puts "source :gemcutter"
           gemfile.puts
           self.extra_deps.each do |name, version|
+            version ||= ">=0"
             gemfile.puts %Q{gem "#{name}", "#{version.gsub(/ /,'')}"}
           end
           gemfile.puts
           self.extra_dev_deps.each do |name, version|
+            version ||= ">=0"
             gemfile.puts %Q{gem "#{name}", "#{version.gsub(/ /,'')}", :group => [:development, :test]}
           end
           gemfile.puts

--- a/test/fixture_project/Gemfile
+++ b/test/fixture_project/Gemfile
@@ -2,12 +2,13 @@
 
 source :gemcutter
 
+gem "xxx", ">=0"
 gem "yyy", ">=0"
 gem "zzz", "<1.5.0"
 
-gem "rubyforge", ">=2.0.4", :group => [:development, :test]
 gem "aaa", ">=0", :group => [:development, :test]
 gem "bbb", ">=2.2.0", :group => [:development, :test]
-gem "hoe", ">=2.6.1", :group => [:development, :test]
+gem "ccc", ">=0", :group => [:development, :test]
+gem "hoe", ">=2.9.1", :group => [:development, :test]
 
 # vim: syntax=ruby

--- a/test/fixture_project/Rakefile
+++ b/test/fixture_project/Rakefile
@@ -4,8 +4,10 @@ $: << File.expand_path(File.join(File.dirname(__FILE__),"../../lib"))
 Hoe.plugin :bundler
 Hoe.spec "fixture_project" do
   developer("MCA","mca@example.com")
+  extra_deps << ["xxx"]
   extra_deps << ["yyy", ">=0"]
   extra_deps << ["zzz", "< 1.5.0"]
   extra_dev_deps << ["aaa", ">=0"]
   extra_dev_deps << ["bbb", ">= 2.2.0"]
+  extra_dev_deps << ["ccc"]
 end

--- a/test/test_hoe_bundler.rb
+++ b/test/test_hoe_bundler.rb
@@ -14,10 +14,12 @@ class TestHoeBundler < Test::Unit::TestCase
 
     assert_match %r{^# -\*- ruby -\*-$}, gemfile
     assert_match %r{^source :gemcutter$}, gemfile
+    assert_match %r{^gem "xxx", ">=0"$}, gemfile
     assert_match %r{^gem "yyy", ">=0"$}, gemfile
     assert_match %r{^gem "zzz", "<1.5.0"$}, gemfile
     assert_match %r{^gem "aaa", ">=0", :group => \[:development, :test\]$}, gemfile
     assert_match %r{^gem "bbb", ">=2.2.0", :group => \[:development, :test\]$}, gemfile
+    assert_match %r{^gem "ccc", ">=0", :group => \[:development, :test\]$}, gemfile
     assert_match %r{^gem "hoe", ">=\d\.\d\.\d", :group => \[:development, :test\]$}, gemfile
     assert_match %r{^# vim: syntax=ruby$}, gemfile
   end


### PR DESCRIPTION
You can be lame and just give the name of a dependency and not specify a version. hoe-bundler would break if you did this, so add a default version of ">= 0".
