### PR TITLE
Suppress a Ruby warning

### DIFF
--- a/lib/hoe/bundler.rb
+++ b/lib/hoe/bundler.rb
@@ -32,8 +32,8 @@ class Hoe #:nodoc:
       end
       extra_deps.each do |name, version|
         output = [%Q{gem "#{name}"}]
-        Array(version).each do |version|
-          output << %Q{"#{version.gsub(/ /,'')}"}
+        Array(version).each do |ver|
+          output << %Q{"#{ver.gsub(/ /,'')}"}
         end
         gemfile.puts output.join(", ")
       end


### PR DESCRIPTION
Here's a fix for a Ruby warning.

```console
% RUBYOPT=-w rake
(snip)
/Users/koic/src/github.com/flavorjones/hoe-bundler/lib/hoe/bundler.rb:35: warning: shadowing outer local variable - version
```

Thanks.
